### PR TITLE
Show docs update metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,5 +7,9 @@ title: Changelog
 ## 2026.05a
 
 - Migrated the documentation site from MkDocs Material to Docusaurus.
-- Published the documentation as Docusaurus version `2026.05a`.
-- Temporarily removed the PDF manual while the site is hosted on Cloudflare Pages.
+- Published the documentation as Docusaurus version `2026.05a` and kept the current docs available as the `Next` version.
+- Reworked the documentation navigation, sidebar structure, homepage, search, and Docusaurus theme styling.
+- Updated the video, audio, Bluetooth, microphone, and troubleshooting documentation for the new site structure.
+- Added GitHub-based edit links plus last-updated time and author metadata on docs pages.
+- Added Cloudflare Pages build support for the Docusaurus static site.
+- Temporarily removed the PDF manual and all public PDF links while the site is hosted on Cloudflare Pages.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,9 +8,9 @@ const docsOptions: DocsOptions = {
   routeBasePath: 'docs',
   sidebarPath: './sidebars.ts',
   editUrl: 'https://github.com/westminsterwooster/wpc-tech-docs-guest/edit/main/',
-  showLastUpdateTime: false,
-  showLastUpdateAuthor: false,
-  includeCurrentVersion: false,
+  showLastUpdateTime: true,
+  showLastUpdateAuthor: true,
+  includeCurrentVersion: true,
   lastVersion: '2026.05a',
   versions: {
     '2026.05a': {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,146 +1,152 @@
-import type {Config} from '@docusaurus/types';
-import type {Options as PresetOptions} from '@docusaurus/preset-classic';
-import type {Options as DocsOptions} from '@docusaurus/plugin-content-docs';
-import type {Options as ThemeOptions} from '@docusaurus/theme-classic';
+import type { Config } from "@docusaurus/types";
+import type { Options as PresetOptions } from "@docusaurus/preset-classic";
+import type { Options as DocsOptions } from "@docusaurus/plugin-content-docs";
+import type { Options as ThemeOptions } from "@docusaurus/theme-classic";
 
 const docsOptions: DocsOptions = {
-  path: 'docs',
-  routeBasePath: 'docs',
-  sidebarPath: './sidebars.ts',
-  editUrl: 'https://github.com/westminsterwooster/wpc-tech-docs-guest/edit/main/',
+  path: "docs",
+  routeBasePath: "docs",
+  sidebarPath: "./sidebars.ts",
+  editUrl:
+    "https://github.com/westminsterwooster/wpc-tech-docs-guest/edit/main/",
   showLastUpdateTime: true,
   showLastUpdateAuthor: true,
   includeCurrentVersion: true,
-  lastVersion: '2026.05a',
+  lastVersion: "2026.05a",
   versions: {
-    '2026.05a': {
-      label: '2026.05a',
-      path: '2026.05a',
-      banner: 'none',
-      badge: false
-    }
-  }
+    current: {
+      label: "Next",
+      path: "next",
+      banner: "unreleased",
+    },
+    "2026.05a": {
+      label: "2026.05a",
+      path: "2026.05a",
+      banner: "none",
+      badge: false,
+    },
+  },
 };
 
 const config: Config = {
-  title: 'Guest Documentation',
-  tagline: 'Westminster Presbyterian Church Mackey Hall Technology',
-  favicon: 'img/WPC_logo.png',
-  url: 'https://docs.wpctech.info',
-  baseUrl: '/',
-  organizationName: 'westminsterwooster',
-  projectName: 'wpc-tech-docs-guest',
+  title: "Guest Documentation",
+  tagline: "Westminster Presbyterian Church Mackey Hall Technology",
+  favicon: "img/WPC_logo.png",
+  url: "https://docs.wpctech.info",
+  baseUrl: "/",
+  organizationName: "westminsterwooster",
+  projectName: "wpc-tech-docs-guest",
   trailingSlash: false,
-  onBrokenLinks: 'warn',
+  onBrokenLinks: "warn",
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: 'warn'
-    }
+      onBrokenMarkdownLinks: "warn",
+    },
   },
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: ["@docusaurus/theme-mermaid"],
   presets: [
     [
-      'classic',
+      "classic",
       {
         docs: docsOptions,
         blog: false,
         theme: {
-          customCss: './src/css/custom.css'
-        } satisfies ThemeOptions
-      } satisfies PresetOptions
-    ]
+          customCss: "./src/css/custom.css",
+        } satisfies ThemeOptions,
+      } satisfies PresetOptions,
+    ],
   ],
   plugins: [
     [
-      '@easyops-cn/docusaurus-search-local',
+      "@easyops-cn/docusaurus-search-local",
       {
         hashed: true,
         indexDocs: true,
         indexPages: true,
         indexBlog: false,
-        docsRouteBasePath: '/docs'
-      }
-    ]
+        docsRouteBasePath: "/docs",
+      },
+    ],
   ],
   themeConfig: {
-    image: 'img/WPC_logo.png',
+    image: "img/WPC_logo.png",
     navbar: {
-      title: 'Guest Documentation',
+      title: "Guest Documentation",
       logo: {
-        alt: 'Westminster Presbyterian Church logo',
-        src: 'img/WPC_logo.png'
+        alt: "Westminster Presbyterian Church logo",
+        src: "img/WPC_logo.png",
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'docsSidebar',
-          position: 'left',
-          label: 'Docs'
+          type: "docSidebar",
+          sidebarId: "docsSidebar",
+          position: "left",
+          label: "Docs",
         },
         {
-          type: 'docsVersionDropdown',
-          position: 'right',
-          dropdownActiveClassDisabled: false
+          type: "docsVersionDropdown",
+          position: "right",
+          dropdownActiveClassDisabled: false,
         },
         {
-          href: 'https://github.com/westminsterwooster/wpc-tech-docs-guest',
-          label: 'GitHub',
-          position: 'right'
-        }
-      ]
+          href: "https://github.com/westminsterwooster/wpc-tech-docs-guest",
+          label: "GitHub",
+          position: "right",
+        },
+      ],
     },
     footer: {
-      style: 'dark',
+      style: "dark",
       links: [
         {
-          title: 'Docs',
+          title: "Docs",
           items: [
             {
-              label: 'Documentation',
-              to: '/docs/2026.05a/documentation/'
-            }
-          ]
+              label: "Documentation",
+              to: "/docs/2026.05a/documentation/",
+            },
+          ],
         },
         {
-          title: 'Westminster',
+          title: "Westminster",
           items: [
             {
-              label: 'Website',
-              href: 'https://wpcwooster.org'
+              label: "Website",
+              href: "https://wpcwooster.org",
             },
             {
-              label: 'Facebook',
-              href: 'https://www.facebook.com/wpcwooster'
+              label: "Facebook",
+              href: "https://www.facebook.com/wpcwooster",
             },
             {
-              label: 'Instagram',
-              href: 'https://www.instagram.com/wpc_wooster'
+              label: "Instagram",
+              href: "https://www.instagram.com/wpc_wooster",
             },
             {
-              label: 'YouTube',
-              href: 'https://www.youtube.com/westminsterwooster'
-            }
-          ]
+              label: "YouTube",
+              href: "https://www.youtube.com/westminsterwooster",
+            },
+          ],
         },
         {
-          title: 'Contact',
+          title: "Contact",
           items: [
             {
-              label: 'Email',
-              href: 'mailto:jack@wpcwooster.org'
-            }
-          ]
-        }
+              label: "Email",
+              href: "mailto:jack@wpcwooster.org",
+            },
+          ],
+        },
       ],
       copyright:
-        'Copyright © 2026 Jack Veney for Westminster Presbyterian Church Wooster, Ohio.'
+        "Copyright © 2026 Jack Veney for Westminster Presbyterian Church Wooster, Ohio.",
     },
     prism: {
-      theme: require('prism-react-renderer').themes.github,
-      darkTheme: require('prism-react-renderer').themes.dracula
-    }
-  } satisfies ThemeOptions
+      theme: require("prism-react-renderer").themes.github,
+      darkTheme: require("prism-react-renderer").themes.dracula,
+    },
+  } satisfies ThemeOptions,
 };
 
 export default config;

--- a/versioned_docs/version-2026.05a/changelog.md
+++ b/versioned_docs/version-2026.05a/changelog.md
@@ -7,5 +7,9 @@ title: Changelog
 ## 2026.05a
 
 - Migrated the documentation site from MkDocs Material to Docusaurus.
-- Published the documentation as Docusaurus version `2026.05a`.
-- Temporarily removed the PDF manual while the site is hosted on Cloudflare Pages.
+- Published the documentation as Docusaurus version `2026.05a` and kept the current docs available as the `Next` version.
+- Reworked the documentation navigation, sidebar structure, homepage, search, and Docusaurus theme styling.
+- Updated the video, audio, Bluetooth, microphone, and troubleshooting documentation for the new site structure.
+- Added GitHub-based edit links plus last-updated time and author metadata on docs pages.
+- Added Cloudflare Pages build support for the Docusaurus static site.
+- Temporarily removed the PDF manual and all public PDF links while the site is hosted on Cloudflare Pages.


### PR DESCRIPTION
## Summary
- Enable Docusaurus last-update time and author metadata on docs pages
- Include the current docs version alongside the versioned 2026.05a docs

## Verification
- `npm.cmd run docs:check-links`
- `npm.cmd run build`