### PR TITLE
Remove deprecated TypeScript baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
+  "extends": "@docusaurus/tsconfig"
 }


### PR DESCRIPTION
Summary: Remove deprecated TypeScript compilerOptions.baseUrl from tsconfig.json.

Verification: npm run typecheck.