### PR TITLE
[codex] Add TypeScript 6 deprecation setting

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@docusaurus/tsconfig"
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
 }


### PR DESCRIPTION
## Summary

Adds compilerOptions.ignoreDeprecations to tsconfig.json for the TypeScript 6 deprecation setting.

## Validation

- Not run; committed and pushed as requested.