### PR TITLE
Open changelog updates as pull requests

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,28 +1,32 @@
 name: Update Changelog
 
 on:
-  push:
+  pull_request_target:
     branches:
       - main
+    types:
+      - closed
   workflow_dispatch:
 
 concurrency:
-  group: changelog-${{ github.ref }}
+  group: changelog-main
   cancel-in-progress: true
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   update:
     name: Update Changelog
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true)
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -35,15 +39,32 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node scripts/update-changelog.mjs
 
-      - name: Commit changelog
+      - name: Open changelog pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet -- docs/changelog.md; then
             echo "Changelog is already current."
             exit 0
           fi
 
+          branch="automation/update-changelog"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
           git add docs/changelog.md
           git commit -m "Update changelog"
-          git push
+          git fetch origin "$branch" || true
+          git push --force-with-lease origin "$branch"
+
+          body="Updates docs/changelog.md from recently merged pull requests.
+
+Co-authored-by: Codex <noreply@openai.com>"
+
+          pr_number="$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number')"
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --title "Update changelog" --body "$body"
+          else
+            gh pr create --base main --head "$branch" --title "Update changelog" --body "$body"
+          fi


### PR DESCRIPTION
﻿## Summary

Fixes the automatic changelog workflow so it respects the protected `main` branch and runs from merged PR events.

## Changes

- Runs the changelog workflow when a pull request into `main` is closed and merged.
- Keeps `workflow_dispatch` for manual catch-up runs.
- Removes the direct `push` to `main` trigger to avoid duplicate runs after merges.
- Checks out the trusted default branch when running under `pull_request_target`.
- Grants the workflow `pull-requests: write` permission.
- Pushes generated changelog changes to `automation/update-changelog` instead of `main`.
- Opens a new changelog PR, or updates the existing open one, when changes are generated.

## Validation

- `node --check scripts/update-changelog.mjs`
- `npm run typecheck`

Co-authored-by: Codex <noreply@openai.com>
